### PR TITLE
WIP: Optimizing the time step

### DIFF
--- a/source/Line.h
+++ b/source/Line.h
@@ -192,7 +192,12 @@ public:
 	void doRHS( const double* X,  double* Xd, const double time, const double dt);
 
 	//void initiateStep(vector<double> &rFairIn, vector<double> &rdFairIn, double time);
-		
+
+	/** @brief Compute the critical time step
+	 * @return The critical time step
+	 */
+	double CriticalTimeStep() const;
+
 	void Output(double );
 	
 	~Line();

--- a/test/Mooring/BodiesAndRods.dat
+++ b/test/Mooring/BodiesAndRods.dat
@@ -41,7 +41,8 @@ Line     LineType NodeA     NodeB  UnstrLen  NumSegs     Flags/Outputs
 5      buoyancy     8          9       50          6        p
 6        cable      9         10       50          6        p
 -------------------------- SOLVER OPTIONS---------------------------------------------------
-0.0001   dtM          - time step to use in mooring integration
+0.01     dtM          - time step to use in mooring integration
+0.25     dtMFactor    - Critical time step multiplier
 3.0e6    kb           - bottom stiffness
 3.0e5    cb           - bottom damping
 70       WtrDpth      - water depth

--- a/test/Mooring/WD0050_Chain.txt
+++ b/test/Mooring/WD0050_Chain.txt
@@ -14,7 +14,8 @@ ID   LineType   AttachA  AttachB  UnstrLen  NumSegs  LineOutputs
 (#)   (name)     (#)      (#)       (m)       (-)     (-)
 1     chain      1        2         410       82      -
 ---------------------- OPTIONS -----------------------------------------
-0.001         dtM                  time step to use in mooring integration (s)
+0.01          dtM                  time step to use in mooring integration (s)
+0.25          dtMFactor            critical time step multiplier
 1.0e5         kBot                 bottom stiffness (Pa/m)
 1.0e4         cBot                 bottom damping (Pa-s/m)
 1025.0        WtrDnsty             water density (kg/m^3)

--- a/test/Mooring/WD0200_Chain.txt
+++ b/test/Mooring/WD0200_Chain.txt
@@ -14,7 +14,8 @@ ID   LineType   AttachA  AttachB  UnstrLen  NumSegs  LineOutputs
 (#)   (name)     (#)      (#)       (m)       (-)     (-)
 1     chain      1        2         760       82      -
 ---------------------- OPTIONS -----------------------------------------
-0.001         dtM                  time step to use in mooring integration (s)
+0.01          dtM                  time step to use in mooring integration (s)
+0.25          dtMFactor            critical time step multiplier
 1.0e5         kBot                 bottom stiffness (Pa/m)
 1.0e4         cBot                 bottom damping (Pa-s/m)
 1025.0        WtrDnsty             water density (kg/m^3)

--- a/test/Mooring/WD0600_Chain.txt
+++ b/test/Mooring/WD0600_Chain.txt
@@ -14,7 +14,8 @@ ID   LineType   AttachA  AttachB  UnstrLen  NumSegs  LineOutputs
 (#)   (name)     (#)      (#)       (m)       (-)     (-)
 1     chain      1        2         1700      82      -
 ---------------------- OPTIONS -----------------------------------------
-0.001         dtM                  time step to use in mooring integration (s)
+0.01          dtM                  time step to use in mooring integration (s)
+0.25          dtMFactor            critical time step multiplier
 1.0e5         kBot                 bottom stiffness (Pa/m)
 1.0e4         cBot                 bottom damping (Pa-s/m)
 1025.0        WtrDnsty             water density (kg/m^3)

--- a/test/Mooring/lines.txt
+++ b/test/Mooring/lines.txt
@@ -20,7 +20,8 @@ ID   LineType   AttachA  AttachB  UnstrLen  NumSegs  LineOutputs
 2     main       2        5         902.2     20      -
 3     main       3        6         902.2     20      -
 ---------------------- OPTIONS -----------------------------------------
-0.002         dtM           time step to use in mooring integration (s)
+0.01          dtM           time step to use in mooring integration (s)
+0.25          dtMFactor     critical time step multiplier
 3.0e6         kBot          bottom stiffness (Pa/m)
 3.0e5         cBot          bottom damping (Pa-s/m)
 1025.0        WtrDnsty      water density (kg/m^3)


### PR DESCRIPTION
I introduced a new option, dtMFactor (we should look for  better name), which is the times the critical time step can be considered. 

For the time being the critical time step is just considering the natural period of the lines (their segments natural period actually), and the velocity of the nodes. Conditions on bodies, rods and so on shall be imposed as well

The tests are working fine. Some of them are a bit faster, some are a bit slower. Tat demonstrates that you can get stable simulations using slightly larger time steps than the critical one, but not to much actually.