### PR TITLE
Line::getStateDeriv() optimization

### DIFF
--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -1083,7 +1083,7 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 				{
 					cout << "   Error: NaN value detected in bending force at Line " << number << " node " << i << endl;
 					cout << lstr[i-1]+lstr[i] << endl;
-					cout << sqrt( 0.5*(1 - dotProd( qs[i-1], qs[i] ) ) ) << endl;
+					cout << sqrt(0.5 * (1 - dotProd3(qs[i-1], qs[i]))) << endl;
 
 					cout << Bs[i-1][J] << endl;
 					cout << Bs[i  ][J] << endl;
@@ -1116,7 +1116,7 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 					// + \sin(\alpha_i) (\uvec{p}_i \times \uvec{s}_\iminus)
 					
 					double p_p_dot_s[3];
-					scalevector( pvec, dotprod(pvec, s[i-1]), p_p_dot_s)  // \uvec{p}_i(\uvec{p}_i \cdot \uvec{s}_\iminus)
+					scalevector( pvec, dotprod3(pvec, s[i-1]), p_p_dot_s)  // \uvec{p}_i(\uvec{p}_i \cdot \uvec{s}_\iminus)
 					
 					double p_cross_s[3];
 					crossprod(pvec, s[i-1], p_cross_s)// \uvec{p}_i \times \uvec{s}_\iminus
@@ -1159,8 +1159,8 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 
 		for (int J=0; J<3; J++) 
 		{
-			vq[J] = dotProd(vi , q[i]) * q[i][J];  // tangential relative flow component  <<<<<<< check sign since I've reversed q
-			vp[J] = vi[J] - vq[J];                 // transverse relative flow component
+			vq[J] = dotProd3(vi , q[i]) * q[i][J];  // tangential relative flow component  <<<<<<< check sign since I've reversed q
+			vp[J] = vi[J] - vq[J];                  // transverse relative flow component
 			vq_squared += vq[J] * vq[J];
 			vp_squared += vp[J] * vp[J];
 		}
@@ -1186,8 +1186,8 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 		
 		// acceleration calculations					
 		for (int J=0; J<3; J++)  {
-			aq[J] = dotProd(Ud[i], q[i]) * q[i][J]; // tangential component of fluid acceleration    <<<<<<< check sign since I've reversed q
-			ap[J] = Ud[i][J] - aq[J]; 			// normal component of fluid acceleration
+			aq[J] = dotProd3(Ud[i], q[i]) * q[i][J];  // tangential component of fluid acceleration    <<<<<<< check sign since I've reversed q
+			ap[J] = Ud[i][J] - aq[J];                 // normal component of fluid acceleration
 		}
 		
 		// transverse Froude-Krylov force

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -1277,11 +1277,14 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 	//	solveCrout(3, LU, F_out, acc);     // solve for acceleration vector
 						
 	//	LUsolve3(M[i], acc, Fnet[i]);
-	
+
+		/*
 		double LU[3][3];
 		double ytemp[3];
 		LUsolve(3, M[i], LU, Fnet[i], ytemp, acc);
-		
+		*/
+		Solve3(M[i], acc, (const double*)Fnet[i]);
+
 		// fill in state derivatives
 		for (int I=0; I<3; I++) 
 		{

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -898,7 +898,8 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 	// calculate unit tangent vectors for either end node if the line has no bending stiffness of if either end is pinned (otherwise it's already been set via setEndStateFromRod)
 	if ((endTypeA == 0) || (EI==0)) unitvector(q[0], r[0  ], r[1]);  
 	if ((endTypeB == 0) || (EI==0)) unitvector(q[N], r[N-1], r[N]);
-
+	
+		
 	//============================================================================================
 	// --------------------------------- apply wave kinematics -----------------------------
 	
@@ -973,13 +974,14 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 		M[i][2][1] = node_mass(2, 1, m_i, v_i, q[i], Can, Cat, env->rho_w);
 		M[i][2][2] = node_mass(2, 2, m_i, v_i, q[i], Can, Cat, env->rho_w);
 	}
+	
 
 	// ============  CALCULATE FORCES ON EACH NODE ===============================
-		
+	
 	// loop through the segments
 	for (int i=0; i<N; i++)
 	{
-
+		
 		/*
 		// attempting error handling <<<<<<<<
 		if (abs(lstr[i]/l[i] - 1) > 0.5) {
@@ -1018,7 +1020,8 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 		Td[i][1] = CA_l * (r[i+1][1] - r[i][1]);
 		Td[i][2] = CA_l * (r[i+1][2] - r[i][2]);
 	}
-
+	
+	
 	// Bending loads
 	// first zero out the forces from last run
 	for (int i=0; i<=N; i++)
@@ -1061,12 +1064,12 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 					Mforce_i[2] = - Mforce_ip1[2];
 
 					// apply these forces to the node forces
-					Bs[i][0] += Mforce_i[0];
-					Bs[i][0] += Mforce_i[0];
-					Bs[i][0] += Mforce_i[0];
-					Bs[i + 1][0] += Mforce_ip1[0];
-					Bs[i + 1][0] += Mforce_ip1[0];
-					Bs[i + 1][0] += Mforce_ip1[0];
+					Bs[i  ][0] += Mforce_i[0];
+					Bs[i  ][0] += Mforce_i[0];
+					Bs[i  ][0] += Mforce_i[0];
+					Bs[i+1][0] += Mforce_ip1[0];
+					Bs[i+1][0] += Mforce_ip1[0];
+					Bs[i+1][0] += Mforce_ip1[0];
 				}
 			}
 			// end node A case (only if attached to a Rod, i.e. a cantilever rather than pinned connection)
@@ -1092,12 +1095,12 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 					Mforce_i[2] = - Mforce_im1[2];
 					
 					// apply these forces to the node forces
-					Bs[i - 1][0] += Mforce_im1[0];
-					Bs[i - 1][0] += Mforce_im1[0];
-					Bs[i - 1][0] += Mforce_im1[0];
-					Bs[i][0] += Mforce_i[0];
-					Bs[i][0] += Mforce_i[0];
-					Bs[i][0] += Mforce_i[0];
+					Bs[i-1][0] += Mforce_im1[0];
+					Bs[i-1][0] += Mforce_im1[0];
+					Bs[i-1][0] += Mforce_im1[0];
+					Bs[i  ][0] += Mforce_i[0];
+					Bs[i  ][0] += Mforce_i[0];
+					Bs[i  ][0] += Mforce_i[0];
 				}
 			}
 			else   // internal node
@@ -1119,15 +1122,15 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 				Mforce_i[2] = - Mforce_im1[2] - Mforce_ip1[2];
 
 				// apply these forces to the node forces
-				Bs[i - 1][0] += Mforce_im1[0];
-				Bs[i - 1][0] += Mforce_im1[0];
-				Bs[i - 1][0] += Mforce_im1[0];
-				Bs[i][0] += Mforce_i[0];
-				Bs[i][0] += Mforce_i[0];
-				Bs[i][0] += Mforce_i[0];
-				Bs[i + 1][0] += Mforce_ip1[0];
-				Bs[i + 1][0] += Mforce_ip1[0];
-				Bs[i + 1][0] += Mforce_ip1[0];
+				Bs[i-1][0] += Mforce_im1[0];
+				Bs[i-1][0] += Mforce_im1[0];
+				Bs[i-1][0] += Mforce_im1[0];
+				Bs[i  ][0] += Mforce_i[0];
+				Bs[i  ][0] += Mforce_i[0];
+				Bs[i  ][0] += Mforce_i[0];
+				Bs[i+1][0] += Mforce_ip1[0];
+				Bs[i+1][0] += Mforce_ip1[0];
+				Bs[i+1][0] += Mforce_ip1[0];
 			}
 
 			// check for NaNs <<<<<<<<<<<<<<< temporary measure <<<<<<<
@@ -1157,10 +1160,14 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 				     << Mforce_ip1[1] << ", "
 				     << Mforce_ip1[2] << endl;
 			}
+			
 			// record curvature at node!!
 			Kurv[i] = Kurvi;
+			
 			// any damping forces for bending? I hope not...
+			
 			// get normal component at each adjacent node
+		
 			// trace along line to find torsion at each segment
 			/*
 			if (torsion)
@@ -1290,9 +1297,9 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 		if (r[i][2] < -env->WtrDpth)
 		{
 			if (i==0)
-				B[i][2] = ( (-env->WtrDpth-r[i][2])*env->kb - rd[i][2]*env->cb) * 0.5*(            l[i] );
+				B[i][2] = ( (-env->WtrDpth-r[i][2])*env->kb - rd[i][2]*env->cb) * 0.5*d*(            l[i] );
 			else if (i==N)
-				B[i][2] = ( (-env->WtrDpth-r[i][2])*env->kb - rd[i][2]*env->cb) * 0.5*( l[i-1]          );
+				B[i][2] = ( (-env->WtrDpth-r[i][2])*env->kb - rd[i][2]*env->cb) * 0.5*d*( l[i-1]          );
 			else
 				B[i][2] = ( (-env->WtrDpth-r[i][2])*env->kb - rd[i][2]*env->cb) * 0.5*d*( l[i-1] + l[i] );
 			

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -1065,11 +1065,11 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 
 					// apply these forces to the node forces
 					Bs[i  ][0] += Mforce_i[0];
-					Bs[i  ][0] += Mforce_i[0];
-					Bs[i  ][0] += Mforce_i[0];
+					Bs[i  ][1] += Mforce_i[1];
+					Bs[i  ][2] += Mforce_i[2];
 					Bs[i+1][0] += Mforce_ip1[0];
-					Bs[i+1][0] += Mforce_ip1[0];
-					Bs[i+1][0] += Mforce_ip1[0];
+					Bs[i+1][1] += Mforce_ip1[1];
+					Bs[i+1][2] += Mforce_ip1[2];
 				}
 			}
 			// end node A case (only if attached to a Rod, i.e. a cantilever rather than pinned connection)
@@ -1096,11 +1096,11 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 					
 					// apply these forces to the node forces
 					Bs[i-1][0] += Mforce_im1[0];
-					Bs[i-1][0] += Mforce_im1[0];
-					Bs[i-1][0] += Mforce_im1[0];
+					Bs[i-1][1] += Mforce_im1[1];
+					Bs[i-1][2] += Mforce_im1[2];
 					Bs[i  ][0] += Mforce_i[0];
-					Bs[i  ][0] += Mforce_i[0];
-					Bs[i  ][0] += Mforce_i[0];
+					Bs[i  ][1] += Mforce_i[1];
+					Bs[i  ][2] += Mforce_i[2];
 				}
 			}
 			else   // internal node
@@ -1123,14 +1123,14 @@ void Line::getStateDeriv(double* Xd, const double PARAM_UNUSED dt)
 
 				// apply these forces to the node forces
 				Bs[i-1][0] += Mforce_im1[0];
-				Bs[i-1][0] += Mforce_im1[0];
-				Bs[i-1][0] += Mforce_im1[0];
+				Bs[i-1][1] += Mforce_im1[1];
+				Bs[i-1][2] += Mforce_im1[2];
 				Bs[i  ][0] += Mforce_i[0];
-				Bs[i  ][0] += Mforce_i[0];
-				Bs[i  ][0] += Mforce_i[0];
+				Bs[i  ][1] += Mforce_i[1];
+				Bs[i  ][2] += Mforce_i[2];
 				Bs[i+1][0] += Mforce_ip1[0];
-				Bs[i+1][0] += Mforce_ip1[0];
-				Bs[i+1][0] += Mforce_ip1[0];
+				Bs[i+1][1] += Mforce_ip1[1];
+				Bs[i+1][2] += Mforce_ip1[2];
 			}
 
 			// check for NaNs <<<<<<<<<<<<<<< temporary measure <<<<<<<

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -824,6 +824,7 @@ void Line::getEndSegmentInfo(double qEnd[3], double *EIout, double *dlout, int t
  * @param Can Normal added mass coefficient
  * @param Cat Tangential added mass coefficient
  * @param rho Water density
+ * @return Mass matrix component
  */
 inline double node_mass(unsigned int i, unsigned int j,
 	                    double m, double v, const double *q,

--- a/source/Line.h
+++ b/source/Line.h
@@ -111,13 +111,6 @@ class Line
 	int endTypeB;
 	double endMomentA[3];   // moment at end A from bending, to be applied on attached Rod/Body
 	double endMomentB[3];
-		
-	// motion component vectors (declaring these here as they caused problems if declared in the loop)
-	double vi[3];           // relative velocity
-	double vp[3];           // transverse component of relative velocity
-	double vq[3];           // axial component of relative velocity
-	double ap[3];           // transverse component of absolute acceleration - HAD TO MOVE THIS UP FROM LOWER DOWN (USED TO CRASH AFTER I=3)
-	double aq[3];           // axial component of absolute acceleration
 
 	// file stuff	
 	ofstream * outfile;     // if not a pointer, caused odeint system initialization error during compilation

--- a/source/Misc.cpp
+++ b/source/Misc.cpp
@@ -481,13 +481,6 @@ int decomposeString(char outWord[10], char let1[10],
 }
 
 
-// simple convenience function for identity matrix
-double eye(int I, int J)
-{
-	if (I==J) return 1.0;
-	else return 0.0;
-}
-
 // produce alternator matrix
 void getH(double r[3], double H[3][3])
 {
@@ -689,30 +682,6 @@ double dotProd( double A[3], double B[3])
 		ans += A[i]*B[i];
 	return ans;
 }
-
-
-void crossProd(double u[3], double v[3], double out[3])
-{
-	out[0] = u[1]*v[2] - u[2]*v[1];
-	out[1] = u[2]*v[0] - u[0]*v[2];
-	out[2] = u[0]*v[1] - u[1]*v[0];
-	return;
-}
-void crossProd(vector<double>& u, vector<double>& v, double out[3])
-{
-	out[0] = u[1]*v[2] - u[2]*v[1];
-	out[1] = u[2]*v[0] - u[0]*v[2];
-	out[2] = u[0]*v[1] - u[1]*v[0];
-	return;
-}
-void crossProd(vector<double>& u, double v[3], double out[3])
-{
-	out[0] = u[1]*v[2] - u[2]*v[1];
-	out[1] = u[2]*v[0] - u[0]*v[2];
-	out[2] = u[0]*v[1] - u[1]*v[0];
-	return;
-}
-
 
 void inverseM3( vector< vector< double > > & minv, vector< vector< double > > & m)
 {		

--- a/source/Misc.cpp
+++ b/source/Misc.cpp
@@ -514,38 +514,6 @@ void getH(double r[3], double H[9])
 	return;
 }
 
-// calculate unit vector (u) in direction from r1 to r2. Also returns distance between points. 
-double unitvector( vector< double > & u, vector< double > & r1, vector< double > & r2)
-{
-	double length_squared = 0.0;	
-	for (int J=0; J<3; J++) length_squared += (r2[J] - r1[J])*(r2[J] - r1[J]);				
-
-	double length = sqrt(length_squared);	
-	for (int J=0; J<3; J++) u[J] = (r2[J] - r1[J]) / length; // write to unit vector
-	
-	return length;
-}
-double unitvector( double u[3], vector< double > & r1, vector< double > & r2)
-{
-	double length_squared = 0.0;	
-	for (int J=0; J<3; J++) length_squared += (r2[J] - r1[J])*(r2[J] - r1[J]);				
-
-	double length = sqrt(length_squared);	
-	for (int J=0; J<3; J++) u[J] = (r2[J] - r1[J]) / length; // write to unit vector
-	
-	return length;
-}
-double unitvector( double u[3], double r1[3], double r2[3])
-{
-	double length_squared = 0.0;	
-	for (int J=0; J<3; J++) length_squared += (r2[J] - r1[J])*(r2[J] - r1[J]);				
-
-	double length = sqrt(length_squared);	
-	for (int J=0; J<3; J++) u[J] = (r2[J] - r1[J]) / length; // write to unit vector
-	
-	return length;
-}
-
 // scale vector to length
 void scalevector( vector< double > & u, double newlength, vector< double > & y)
 {

--- a/source/Misc.h
+++ b/source/Misc.h
@@ -518,6 +518,90 @@ void LUsolve(int n, TwoD1& A, TwoD2& LU, double*b, double *y, double*x)
 void LUsolve3(double A[3][3], double x[3], double b[3]);
 void LUsolve6(const double A[6][6], double x[6], const double b[6]);
 
+/** @brief Compute 3x3 matrices determinant
+ * @param m The matrix
+ */
+template <typename T>
+inline double DetM3(const T **m)
+{
+	return m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) -
+	       m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+	       m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+}
+
+/** @brief Invert a 3x3 matrix
+ * @param m The matrix to invert
+ * @return The matrix determinant
+ * @warning This function is overwriting the matrix
+ * @note This function computes the invert without checking for non-null
+ * determinants
+ * @note This function is way faster than any LU decomposition for 3x3 matrices
+ */
+template <typename T>
+inline double InvM3(T **m)
+{
+	T minv[3][3];
+	const double det = DetM3((const T**)m);
+	const double idet = 1.0 / det;
+
+	minv[0][0] = (m[1][1] * m[2][2] - m[2][1] * m[1][2]) * idet;
+	minv[0][1] = (m[0][2] * m[2][1] - m[0][1] * m[2][2]) * idet;
+	minv[0][2] = (m[0][1] * m[1][2] - m[0][2] * m[1][1]) * idet;
+	minv[1][0] = (m[1][2] * m[2][0] - m[1][0] * m[2][2]) * idet;
+	minv[1][1] = (m[0][0] * m[2][2] - m[0][2] * m[2][0]) * idet;
+	minv[1][2] = (m[1][0] * m[0][2] - m[0][0] * m[1][2]) * idet;
+	minv[2][0] = (m[1][0] * m[2][1] - m[2][0] * m[1][1]) * idet;
+	minv[2][1] = (m[2][0] * m[0][1] - m[0][0] * m[2][1]) * idet;
+	minv[2][2] = (m[0][0] * m[1][1] - m[1][0] * m[0][1]) * idet;
+
+	memcpy(m[0], minv[0], 3 * sizeof(T));
+	memcpy(m[1], minv[1], 3 * sizeof(T));
+	memcpy(m[2], minv[2], 3 * sizeof(T));
+	return det;
+}
+
+/** @brief Inner product of 3D vectors
+ * @param a First vector
+ * @param b Second vector
+ * @return the inner product result
+ * @note This function is way faster than any other general solution
+ */
+template <typename T>
+inline T dotProd3(const T *a, const T *b)
+{
+	return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+/** @brief Solve a 3x3 linear system
+ * @param m The matrix to invert
+ * @return The matrix determinant
+ * @warning This function is overwriting the matrix
+ * @note This function does not check if the matrix is actually invertible
+ * @note This function is way faster than any LU decomposition for 3x3 matrices
+ */
+template <typename T>
+inline double Solve3(T **m, T *x, const T *b)
+{
+	const double det = InvM3(m);
+	x[0] = dotProd3((const T*)m[0], b);
+	x[1] = dotProd3((const T*)m[1], b);
+	x[2] = dotProd3((const T*)m[2], b);
+	return det;
+}
+
+/** @brief Duplicate a matrix
+ * @param src The original matrix
+ * @param dst The duplicate
+ */
+template <typename T>
+inline void CopyMat(int n, const T **src, T **dst)
+{
+	for(int i=0; i<n; ++i)
+	{
+		memcpy(dst[i], src[i], n * sizeof(T));
+	}
+}
+
 void RotMat( double x1, double x2, double x3, double TransMat[]);
 
 void QuaternionToDCM(double q[4], double outMat[3][3]);

--- a/source/Misc.h
+++ b/source/Misc.h
@@ -436,9 +436,34 @@ double eye(int I, int J);
 void getH(double r[3], double H[3][3]);
 void getH(double r[3], double H[9]);
 
-double unitvector( vector< double > & u, vector< double > & r1, vector< double > & r2);
-double unitvector( double u[3], vector< double > & r1, vector< double > & r2);
-double unitvector( double u[3], double r1[3], double r2[3]);
+/** @brief Normalized direction vector
+ * @param u The output normalized direction vector
+ * @param r1 The orig point
+ * @param r2 The dest point
+ * @return The distance between the points
+ */
+template <typename T>
+inline double unitvector(T *u, const T *r1, const T *r2)
+{
+	const T v[3] = {r2[0] - r1[0], r2[1] - r1[1], r2[2] - r1[2]};
+	const double l = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+	u[0] = v[0] / l;
+	u[1] = v[1] / l;
+	u[2] = v[2] / l;
+	return l;
+}
+
+template <typename T>
+inline double unitvector(vector<T> &u, vector<T> & r1, vector<T> & r2)
+{
+	return unitvector(u.data(), r1.data(), r2.data());
+}
+
+template <typename T>
+inline double unitvector(T *u, vector<T> & r1, vector<T> & r2)
+{
+	return unitvector(u, r1.data(), r2.data());
+}
 
 void transposeM3(double A[3][3], double Atrans[3][3]);
 void transposeM3(double A[9], double Atrans[9]);


### PR DESCRIPTION
One of the main bottlenecks of the code is obviously the solution of linear systems, which is called for each single line node. For instance in test_bodies_and_rods:

![callgrind out 19020](https://user-images.githubusercontent.com/1668392/158571675-31542431-0f27-490e-85ad-ffddb7395801.png)

Line:getStateDeriv() takes a vast majority of the total computation (79.82%), and inside that function the heaviest load is in LuSolve calls (11.13%). Replacing the LU solver by a more straightforward approach, unfolded with inlines for further optimization, the load of that chunk of code is significantly reduced:

![callgrind out 18136](https://user-images.githubusercontent.com/1668392/158570441-88b3b4c6-de99-4599-a4fd-4b709557e3f2.png)

The linear systems solving (called Solve3()) is taking now 6.99% of the total load in Line:getStateDeriv(), becoming comparable with some other unoptimized functions like unitvector() and dotProduct(). That allows to shrink the overall load of Line:getStateDeriv() to 78.86%

Let me know so I replace the solver everywhere, and continue optimizing some other helper functions (like unitvector() and dotProduct())